### PR TITLE
Ditch 'dapp_dev_invoice' mention

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -203,9 +203,8 @@
             <h3>Contribute code</h3>
             <ul>
               <li>
-                Check out GitHub issues with the tags
-                <code>Good first issue</code>, <code>bounty</code> or
-                <code>dapp_dev_invoice</code>.
+                Check out GitHub issues with the
+                <a href="https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Aleapdao+label%3A%22Good+first+issue%22+"><code>Good first issue</code></a> or <a href="https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Aleapdao+label%3A%22bounty%22+"><code>bounty</code></a> tags.
               </li>
               <li>Report a bug and find a solution for it.</li>
               <li>Propose new features or solve design challenges.</li>


### PR DESCRIPTION
- removed 'dapp_dev_invoice' label - it is not used anymore (is it?)
- added issue lists links