### PR TITLE
fix: do not show 'monthly active UTXOs' until data is loaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           <br><br>
           <div class="stats-repos">
             <div class="stats-repo">
-              <strong id="utxos"></strong> monthly active UTXOs
+              <strong id="utxos" class="stats-repo-data"></strong><span> monthly active UTXOs</span>
             </div>
             <div class="stats-repo" id="members"></div>
             <div class="stats-repo" id="contributors"></div>

--- a/main.css
+++ b/main.css
@@ -811,6 +811,10 @@ input:focus {
   font-weight: bold;
 }
 
+.stats-repo-data:empty + span {
+  display: none;
+}
+
 @media screen and (max-width: 900px) {
   .blog-post hr {
     margin-top: 3rem;


### PR DESCRIPTION
Otherwise looks ugly when data is still loading.