### PR TITLE
feat: hide 'monthly active UTXOs' as it shows false data.

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@
 
   fetchContributors();
   fetchMembers();
-  fetchUTXO();
+  //fetchUTXO();
 })();
 
 (function() {


### PR DESCRIPTION
We should show it once we have real data (ideally w/o sniper rifle txs).

Works best with #75