### PR TITLE
fix: remove mainnet UTXO metric

### DIFF
--- a/src/routes/_index/Stats.svelte
+++ b/src/routes/_index/Stats.svelte
@@ -3,7 +3,6 @@
 
   let contributors = 0;
   let members = 0;
-  let utxos = 0;
 
   const fetchContributors = () => {
     fetch("https://api.github.com/orgs/leapdao/repos")
@@ -37,16 +36,9 @@
       .then(data => members = data);
   };
 
-  const fetchUTXO = () => {
-    fetch(`https://zy2mo76rd6.execute-api.eu-west-1.amazonaws.com/mainnet/stats/get`)
-      .then(response => response.json())
-      .then(data => utxos = data.count);
-  };
-
   onMount(() => {
     fetchContributors();
     fetchMembers();
-    fetchUTXO();
   });
 </script>
 
@@ -63,10 +55,6 @@
 
 <div class="stats">
   <div class="stats-repos">
-    <div class="stats-repo">
-      <strong id="utxos" class="stats-repo-data">{utxos}</strong>
-      <span> monthly active UTXOs</span>
-    </div>
     <div class="stats-repo">
       <strong id="members" class="stats-repo-data">{members}</strong>
       <span>&nbsp;members</span>


### PR DESCRIPTION
With [mainnet shutdown](https://leapdao.org/blog/mainnet-shutdown) the metric doesn't make sense anymore